### PR TITLE
Updated zarr requirementes to v3.0 [FUTURE RELEASE]

### DIFF
--- a/requirements/requirements-all.txt
+++ b/requirements/requirements-all.txt
@@ -1,7 +1,7 @@
 yacman >= 0.9.1
 sqlalchemy >= 2.0.0
 gtars >= 0.4.0
-geniml[ml] >= 0.8.2
+geniml[ml] >= 0.8.3
 psycopg >= 3.1.15
 coloredlogs
 pydantic >= 2.9.0
@@ -9,7 +9,7 @@ botocore >= 1.34.0, < 1.36.0
 boto3 >= 1.34.54, < 1.36.0
 pephubclient >= 0.4.5
 sqlalchemy_schemadisplay
-zarr < 3.0.0
+zarr >= 3.0.0
 pyyaml >= 6.0.1 # for s3fs because of the errors
 s3fs >= 2024.3.1
 pandas >= 2.0.0


### PR DESCRIPTION
⚠️ This PR is not ready.
Zarr 3.1 requires Python 3.11, but we want to keep compatibility with Python 3.10 until it reaches end of life.