### PR TITLE
Modernize - phase 4 - types update

### DIFF
--- a/bbconf/__init__.py
+++ b/bbconf/__init__.py
@@ -3,6 +3,7 @@ import logging
 import coloredlogs
 
 from bbconf.bbagent import BedBaseAgent
+
 from .const import PKG_NAME
 
 __all__ = ["BedBaseAgent"]

--- a/bbconf/bbagent.py
+++ b/bbconf/bbagent.py
@@ -112,7 +112,6 @@ class BedBaseAgent:
         _LOGGER.info("Getting detailed statistics for all bed files")
 
         with Session(self.config.db_engine.engine) as session:
-
             bed_compliance = {
                 f[0]: f[1]
                 for f in session.execute(
@@ -384,7 +383,6 @@ class BedBaseAgent:
     def add_usage(self, stats: UsageModel) -> None:
 
         with Session(self.config.db_engine.engine) as session:
-
             # FILES USAGE
             reported_items_files = session.scalars(
                 select(UsageFiles).where(UsageFiles.date_to > func.now())

--- a/bbconf/bbagent.py
+++ b/bbconf/bbagent.py
@@ -2,11 +2,10 @@ import logging
 import statistics
 from functools import cached_property
 from pathlib import Path
-from typing import Dict, List, Union
 
 import numpy as np
-from sqlalchemy.orm import Session
 from sqlalchemy.engine import ScalarResult
+from sqlalchemy.orm import Session
 from sqlalchemy.sql import and_, distinct, func, or_, select
 
 from bbconf.config_parser.bedbaseconfig import BedBaseConfig
@@ -18,11 +17,11 @@ from bbconf.db_utils import (
     Files,
     GeoGsmStatus,
     License,
+    ReferenceGenome,
     UsageBedMeta,
     UsageBedSetMeta,
     UsageFiles,
     UsageSearch,
-    ReferenceGenome,
 )
 from bbconf.models.base_models import (
     AllFilesInfo,
@@ -43,10 +42,10 @@ from .const import PKG_NAME
 _LOGGER = logging.getLogger(PKG_NAME)
 
 
-class BedBaseAgent(object):
+class BedBaseAgent:
     def __init__(
         self,
-        config: Union[Path, str],
+        config: Path | str,
         init_ml: bool = True,
     ):
         """
@@ -339,7 +338,7 @@ class BedBaseAgent(object):
             bed_downloads=bed_downloads,
         )
 
-    def get_list_genomes(self) -> List[str]:
+    def get_list_genomes(self) -> list[str]:
         """
         Get list of genomes from the database
 
@@ -354,7 +353,7 @@ class BedBaseAgent(object):
             genomes = session.execute(statement).all()
         return [result[0] for result in genomes if result[0]]
 
-    def get_list_assays(self):
+    def get_list_assays(self) -> list[str]:
         """
         Get list of genomes from the database
 
@@ -371,7 +370,7 @@ class BedBaseAgent(object):
         return [result[0] for result in results if result[0]]
 
     @cached_property
-    def list_of_licenses(self) -> List[str]:
+    def list_of_licenses(self) -> list[str]:
         """
         Get list of licenses from the database
 
@@ -497,7 +496,7 @@ class BedBaseAgent(object):
 
             session.commit()
 
-    def _stats_comments(self, sa_session: Session) -> Dict[str, int]:
+    def _stats_comments(self, sa_session: Session) -> dict[str, int]:
         """
         Get statistics about comments that are present in bed files.
 
@@ -551,7 +550,7 @@ class BedBaseAgent(object):
             "header_comments": header_comments,
         }
 
-    def _stats_geo_status(self, sa_session: Session) -> Dict[str, int]:
+    def _stats_geo_status(self, sa_session: Session) -> dict[str, int]:
         """
         Get statistics about status of GEO bed file processing.
 
@@ -801,7 +800,7 @@ class BedBaseAgent(object):
             ),
         )
 
-    def get_reference_genomes(self) -> Dict[str, str]:
+    def get_reference_genomes(self) -> dict[str, str]:
         """
         Get mapping of genome aliases to reference genome names.
 

--- a/bbconf/config_parser/bedbaseconfig.py
+++ b/bbconf/config_parser/bedbaseconfig.py
@@ -74,7 +74,6 @@ class BedBaseConfig:
             init_ml = False
 
         if init_ml:
-
             self.dense_encoder: TextEmbedding = self._init_dense_encoder()
             self.sparse_encoder: SparseEncoder | None = self._init_sparce_model()
             self.umap_encoder: UMAP | None = self._init_umap_model()
@@ -487,7 +486,6 @@ class BedBaseConfig:
         model_path = self.config.path.umap_model
         umap_model = None
         if model_path.startswith(("http://", "https://")):
-
             try:
                 response = requests.get(model_path)
                 response.raise_for_status()

--- a/bbconf/config_parser/models.py
+++ b/bbconf/config_parser/models.py
@@ -1,6 +1,5 @@
 import logging
 from pathlib import Path
-from typing import Optional, Union
 
 from pydantic import BaseModel, ConfigDict, computed_field, field_validator
 from yacman import load_yaml
@@ -35,7 +34,7 @@ class ConfigDB(BaseModel):
     password: str
     database: str = DEFAULT_DB_NAME
     dialect: str = DEFAULT_DB_DIALECT
-    driver: Optional[str] = DEFAULT_DB_DRIVER
+    driver: str | None = DEFAULT_DB_DRIVER
 
     model_config = ConfigDict(extra="forbid")
 
@@ -53,10 +52,10 @@ class ConfigDB(BaseModel):
 class ConfigQdrant(BaseModel):
     host: str
     port: int = DEFAULT_QDRANT_PORT
-    api_key: Optional[str] = None
+    api_key: str | None = None
     file_collection: str = DEFAULT_QDRANT_FILE_COLLECTION_NAME
-    text_collection: Optional[str] = DEFAULT_QDRANT_BIVEC_COLLECTION_NAME
-    hybrid_collection: Optional[str] = DEFAULT_QDRANT_HYBRID_COLLECTION_NAME
+    text_collection: str | None = DEFAULT_QDRANT_BIVEC_COLLECTION_NAME
+    hybrid_collection: str | None = DEFAULT_QDRANT_HYBRID_COLLECTION_NAME
 
 
 class ConfigServer(BaseModel):
@@ -69,7 +68,7 @@ class ConfigPath(BaseModel):
     # vec2vec: str = DEFAULT_VEC2VEC_MODEL
     text2vec: str = DEFAULT_TEXT2VEC_MODEL
     sparse_model: str = DEFAULT_SPARSE_MODEL
-    umap_model: Union[str, None] = None  # Path or link to pre-trained UMAP model
+    umap_model: str | None = None  # Path or link to pre-trained UMAP model
 
 
 class AccessMethodsStruct(BaseModel):
@@ -85,10 +84,10 @@ class AccessMethods(BaseModel):
 
 
 class ConfigS3(BaseModel):
-    endpoint_url: Union[str, None] = None
-    aws_access_key_id: Union[str, None] = None
-    aws_secret_access_key: Union[str, None] = None
-    bucket: Union[str, None] = DEFAULT_S3_BUCKET
+    endpoint_url: str | None = None
+    aws_access_key_id: str | None = None
+    aws_secret_access_key: str | None = None
+    bucket: str | None = DEFAULT_S3_BUCKET
 
     @field_validator("aws_access_key_id", "aws_secret_access_key")
     def validate_aws_credentials(cls, value):
@@ -120,9 +119,9 @@ class ConfigS3(BaseModel):
 
 
 class ConfigPepHubClient(BaseModel):
-    namespace: Union[str, None] = DEFAULT_PEPHUB_NAMESPACE
-    name: Union[str, None] = DEFAULT_PEPHUB_NAME
-    tag: Union[str, None] = DEFAULT_PEPHUB_TAG
+    namespace: str | None = DEFAULT_PEPHUB_NAMESPACE
+    name: str | None = DEFAULT_PEPHUB_NAME
+    tag: str | None = DEFAULT_PEPHUB_TAG
 
 
 class ConfigFile(BaseModel):

--- a/bbconf/config_parser/utils.py
+++ b/bbconf/config_parser/utils.py
@@ -1,10 +1,14 @@
+import logging
+
 import yacman
 from pephubclient.helpers import MessageHandler as m
 from pydantic_core._pydantic_core import ValidationError
 
 from bbconf.config_parser.models import ConfigFile
-from bbconf.exceptions import BedBaseConfError
+from bbconf.const import PKG_NAME
 from bbconf.helpers import get_bedbase_cfg
+
+_LOGGER = logging.getLogger(PKG_NAME)
 
 
 def config_analyzer(config_path: str) -> bool:
@@ -17,7 +21,7 @@ def config_analyzer(config_path: str) -> bool:
     """
     config_path = get_bedbase_cfg(config_path)
 
-    print(f"Analyzing the configuration file {config_path}...")
+    _LOGGER.info(f"Analyzing the configuration file {config_path}...")
 
     _config = yacman.YAMLConfigManager(filepath=config_path).exp
 
@@ -27,35 +31,23 @@ def config_analyzer(config_path: str) -> bool:
             config_dict[field_name] = annotation.annotation(**_config.get(field_name))
         except TypeError:
             if annotation.is_required():
-                print(
-                    str(
-                        BedBaseConfError(
-                            f"`Config info: {field_name}` Field is not set in the configuration file or missing. "
-                        )
-                    )
+                _LOGGER.error(
+                    f"`Config info: {field_name}` Field is not set in the configuration file or missing."
                 )
             else:
-                print(
+                _LOGGER.info(
                     f"Config info: `{field_name}` Field is not set in the configuration file. Using default value."
                 )
             try:
                 config_dict[field_name] = None
             except ValidationError as e:
-                print(
-                    str(
-                        BedBaseConfError(
-                            f"Error in provided configuration file. Section: `{field_name}` missing values :: \n {e}"
-                        )
-                    )
+                _LOGGER.error(
+                    f"Error in provided configuration file. Section: `{field_name}` missing values :: \n {e}"
                 )
                 return False
         except ValidationError as e:
-            print(
-                str(
-                    BedBaseConfError(
-                        f"Error in provided configuration file. Section: `{field_name}` missing values :: \n {e}"
-                    )
-                )
+            _LOGGER.error(
+                f"Error in provided configuration file. Section: `{field_name}` missing values :: \n {e}"
             )
             return False
 

--- a/bbconf/db_utils.py
+++ b/bbconf/db_utils.py
@@ -1,6 +1,6 @@
 import datetime
 import logging
-from typing import List, Optional
+from typing import Optional
 
 import pandas as pd
 from sqlalchemy import (
@@ -117,11 +117,11 @@ class Bed(Base):
     )
     is_universe: Mapped[Optional[bool]] = mapped_column(default=False)
 
-    files: Mapped[List["Files"]] = relationship(
+    files: Mapped[list["Files"]] = relationship(
         "Files", back_populates="bedfile", cascade="all, delete-orphan"
     )
 
-    bedsets: Mapped[List["BedFileBedSetRelation"]] = relationship(
+    bedsets: Mapped[list["BedFileBedSetRelation"]] = relationship(
         "BedFileBedSetRelation", back_populates="bedfile", cascade="all, delete-orphan"
     )
 
@@ -144,7 +144,7 @@ class Bed(Base):
     )
     license_mapping: Mapped["License"] = relationship("License", back_populates="bed")
 
-    ref_classifier: Mapped[List["GenomeRefStats"]] = relationship(
+    ref_classifier: Mapped[list["GenomeRefStats"]] = relationship(
         "GenomeRefStats", back_populates="bed", cascade="all, delete-orphan"
     )
     processed: Mapped[bool] = mapped_column(
@@ -337,10 +337,10 @@ class BedSets(Base):
         JSON, comment="Median values of the bedset"
     )
 
-    bedfiles: Mapped[List["BedFileBedSetRelation"]] = relationship(
+    bedfiles: Mapped[list["BedFileBedSetRelation"]] = relationship(
         "BedFileBedSetRelation", back_populates="bedset", cascade="all, delete-orphan"
     )
-    files: Mapped[List["Files"]] = relationship("Files", back_populates="bedset")
+    files: Mapped[list["Files"]] = relationship("Files", back_populates="bedset")
     universe: Mapped["Universes"] = relationship("Universes", back_populates="bedset")
 
     author: Mapped[str] = mapped_column(nullable=True, comment="Author of the bedset")
@@ -413,7 +413,7 @@ class License(Base):
         nullable=False, comment="License description"
     )
 
-    bed: Mapped[List["Bed"]] = relationship("Bed", back_populates="license_mapping")
+    bed: Mapped[list["Bed"]] = relationship("Bed", back_populates="license_mapping")
 
 
 class ReferenceGenome(Base):
@@ -424,7 +424,7 @@ class ReferenceGenome(Base):
         nullable=False, comment="Name of the reference genome"
     )
 
-    bed_reference: Mapped[List["GenomeRefStats"]] = relationship(
+    bed_reference: Mapped[list["GenomeRefStats"]] = relationship(
         "GenomeRefStats",
         back_populates="genome_object",
         cascade="all, delete-orphan",
@@ -501,7 +501,7 @@ class GeoGseStatus(Base):
     number_of_skips: Mapped[int] = mapped_column(default=0, comment="Number of skips")
     number_of_fails: Mapped[int] = mapped_column(default=0, comment="Number of fails")
 
-    gsm_status_mapper: Mapped[List["GeoGsmStatus"]] = relationship(
+    gsm_status_mapper: Mapped[list["GeoGsmStatus"]] = relationship(
         "GeoGsmStatus", back_populates="gse_status_mapper"
     )
     error: Mapped[str] = mapped_column(nullable=True, comment="Error message")
@@ -607,10 +607,10 @@ class BaseEngine:
         host: str = "localhost",
         port: int = 5432,
         database: str = "bedbase",
-        user: str = None,
-        password: str = None,
+        user: str | None = None,
+        password: str | None = None,
         drivername: str = POSTGRES_DIALECT,
-        dsn: str = None,
+        dsn: str | None = None,
         echo: bool = False,
     ):
         """

--- a/bbconf/models/base_models.py
+++ b/bbconf/models/base_models.py
@@ -1,5 +1,4 @@
 import datetime
-from typing import Dict, List, Optional, Union
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -8,14 +7,14 @@ from .drs_models import AccessMethod
 
 class FileModel(BaseModel):
     name: str
-    title: Optional[str] = None
+    title: str | None = None
     path: str
-    file_digest: Optional[str] = None
-    path_thumbnail: Optional[Union[str, None]] = Field(None, alias="thumbnail_path")
-    description: Optional[str] = None
-    size: Optional[int] = None
-    object_id: Optional[str] = None
-    access_methods: List[AccessMethod] = None
+    file_digest: str | None = None
+    path_thumbnail: str | None = Field(None, alias="thumbnail_path")
+    description: str | None = None
+    size: int | None = None
+    object_id: str | None = None
+    access_methods: list[AccessMethod] | None = None
 
     model_config = ConfigDict(populate_by_name=True, extra="ignore")
 
@@ -28,11 +27,11 @@ class StatsReturn(BaseModel):
 
 class UsageStats(BaseModel):
     # file_downloads: Dict[str, int]   # Placeholder for tracking file download statistics in the future.
-    bed_metadata: Dict[str, int]
-    bedset_metadata: Dict[str, int]
-    bed_search_terms: Dict[str, int]
-    bedset_search_terms: Dict[str, int]
-    bed_downloads: Dict[str, int]
+    bed_metadata: dict[str, int]
+    bedset_metadata: dict[str, int]
+    bed_search_terms: dict[str, int]
+    bedset_search_terms: dict[str, int]
+    bed_downloads: dict[str, int]
 
 
 class UsageModel(BaseModel):
@@ -40,15 +39,15 @@ class UsageModel(BaseModel):
     Usage model. Used to track usage of the bedbase.
     """
 
-    bed_meta: Union[dict, None] = Dict[str, int]
-    bedset_meta: Union[dict, None] = Dict[str, int]
+    bed_meta: dict[str, int] | None = None
+    bedset_meta: dict[str, int] | None = None
 
-    bed_search: Union[dict, None] = Dict[str, int]
-    bedset_search: Union[dict, None] = Dict[str, int]
-    files: Union[dict, None] = Dict[str, int]
+    bed_search: dict[str, int] | None = None
+    bedset_search: dict[str, int] | None = None
+    files: dict[str, int] | None = None
 
     date_from: datetime.datetime
-    date_to: Union[datetime.datetime, None] = None
+    date_to: datetime.datetime | None = None
 
 
 class FileInfo(BaseModel):
@@ -71,12 +70,12 @@ class AllFilesInfo(BaseModel):
     """
 
     total: int
-    files: List[FileInfo]
+    files: list[FileInfo]
 
 
 class BinValues(BaseModel):
-    bins: List[Union[int, float, str]]
-    counts: List[int]
+    bins: list[int | float | str]
+    counts: list[int]
     mean: float
     median: float
 
@@ -86,20 +85,20 @@ class GEOStatistics(BaseModel):
     GEO statistics for files.
     """
 
-    number_of_files: Dict[str, int]
-    cumulative_number_of_files: Dict[str, int]
+    number_of_files: dict[str, int]
+    cumulative_number_of_files: dict[str, int]
     file_sizes: BinValues
 
 
 class FileStats(BaseModel):
-    bed_compliance: Dict[str, int]
-    data_format: Dict[str, int]
-    file_genome: Dict[str, int]
-    file_organism: Dict[str, int]
-    file_assay: Dict[str, int]
-    cell_line: Dict[str, int]
-    geo_status: Dict[str, int]
-    bed_comments: Dict[str, int]
+    bed_compliance: dict[str, int]
+    data_format: dict[str, int]
+    file_genome: dict[str, int]
+    file_organism: dict[str, int]
+    file_assay: dict[str, int]
+    cell_line: dict[str, int]
+    geo_status: dict[str, int]
+    bed_comments: dict[str, int]
     mean_region_width: BinValues
     file_size: BinValues
     number_of_regions: BinValues

--- a/bbconf/models/bed_models.py
+++ b/bbconf/models/bed_models.py
@@ -165,7 +165,6 @@ class StandardMeta(BaseModel):
 
 
 class BedPEPHubRestrict(BedPEPHub):
-
     model_config = ConfigDict(extra="ignore")
 
 

--- a/bbconf/models/bed_models.py
+++ b/bbconf/models/bed_models.py
@@ -1,5 +1,4 @@
 import datetime
-from typing import List, Optional, Union
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
@@ -23,8 +22,8 @@ class BedPlots(BaseModel):
 
 
 class BedFiles(BaseModel):
-    bed_file: Union[FileModel, None] = None
-    bigbed_file: Union[FileModel, None] = None
+    bed_file: FileModel | None = None
+    bigbed_file: FileModel | None = None
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -33,47 +32,47 @@ class BedFiles(BaseModel):
 
 
 class BedClassification(BaseModel):
-    name: Optional[str] = None
-    genome_alias: str = None
-    genome_digest: Union[str, None] = None
+    name: str | None = None
+    genome_alias: str | None = None
+    genome_digest: str | None = None
     bed_compliance: str = Field(
         default="bed3", pattern=r"^bed(?:[3-9]|1[0-5])(?:\+|$)[0-9]?+$"
     )
-    data_format: Union[str, None] = None
+    data_format: str | None = None
     compliant_columns: int = 3
     non_compliant_columns: int = 0
 
-    header: Union[str, None] = None  # Header of the bed file (if any)
+    header: str | None = None  # Header of the bed file (if any)
 
     model_config = ConfigDict(extra="ignore")
 
 
 class BedStatsModel(BaseModel):
-    number_of_regions: Optional[float] = None
-    gc_content: Optional[float] = None
-    median_tss_dist: Optional[float] = None
-    mean_region_width: Optional[float] = None
+    number_of_regions: float | None = None
+    gc_content: float | None = None
+    median_tss_dist: float | None = None
+    mean_region_width: float | None = None
 
-    exon_frequency: Optional[float] = None
-    exon_percentage: Optional[float] = None
+    exon_frequency: float | None = None
+    exon_percentage: float | None = None
 
-    intron_frequency: Optional[float] = None
-    intron_percentage: Optional[float] = None
+    intron_frequency: float | None = None
+    intron_percentage: float | None = None
 
-    intergenic_percentage: Optional[float] = None
-    intergenic_frequency: Optional[float] = None
+    intergenic_percentage: float | None = None
+    intergenic_frequency: float | None = None
 
-    promotercore_frequency: Optional[float] = None
-    promotercore_percentage: Optional[float] = None
+    promotercore_frequency: float | None = None
+    promotercore_percentage: float | None = None
 
-    fiveutr_frequency: Optional[float] = None
-    fiveutr_percentage: Optional[float] = None
+    fiveutr_frequency: float | None = None
+    fiveutr_percentage: float | None = None
 
-    threeutr_frequency: Optional[float] = None
-    threeutr_percentage: Optional[float] = None
+    threeutr_frequency: float | None = None
+    threeutr_percentage: float | None = None
 
-    promoterprox_frequency: Optional[float] = None
-    promoterprox_percentage: Optional[float] = None
+    promoterprox_frequency: float | None = None
+    promoterprox_percentage: float | None = None
 
     model_config = ConfigDict(extra="ignore", populate_by_name=True)
 
@@ -114,7 +113,7 @@ class StandardMeta(BaseModel):
     species_id: str = ""
     genotype: str = Field("", description="Genotype of the sample")
     phenotype: str = Field("", description="Phenotype of the sample")
-    description: Union[str, None] = ""
+    description: str | None = ""
 
     cell_type: str = Field(
         "",
@@ -139,10 +138,10 @@ class StandardMeta(BaseModel):
         "", description="Treatment of the sample (e.g. drug treatment)"
     )
 
-    global_sample_id: Union[List[str], None] = Field(
+    global_sample_id: list[str] | None = Field(
         "", description="Global sample identifier. e.g. GSM000"
     )  # excluded in training
-    global_experiment_id: Union[List[str], None] = Field(
+    global_experiment_id: list[str] | None = Field(
         "", description="Global experiment identifier. e.g. GSE000"
     )  # excluded in training
 
@@ -155,7 +154,7 @@ class StandardMeta(BaseModel):
     )
 
     @field_validator("global_sample_id", "global_experiment_id", mode="before")
-    def ensure_list(cls, v: Union[str, List[str]]) -> List[str]:
+    def ensure_list(cls, v: str | list[str]) -> list[str]:
         if isinstance(v, str):
             return [v]
         elif isinstance(v, list):
@@ -172,67 +171,67 @@ class BedPEPHubRestrict(BedPEPHub):
 
 class BedMetadataBasic(BedClassification):
     id: str
-    name: Optional[Union[str, None]] = ""
-    description: Optional[str] = None
-    submission_date: datetime.datetime = None
-    last_update_date: Optional[datetime.datetime] = None
-    is_universe: Optional[bool] = False
-    license_id: Optional[str] = DEFAULT_LICENSE
-    annotation: Optional[StandardMeta] = None
-    processed: Optional[bool] = True
+    name: str | None = ""
+    description: str | None = None
+    submission_date: datetime.datetime | None = None
+    last_update_date: datetime.datetime | None = None
+    is_universe: bool | None = False
+    license_id: str | None = DEFAULT_LICENSE
+    annotation: StandardMeta | None = None
+    processed: bool | None = True
 
 
 class UniverseMetadata(BaseModel):
-    construct_method: Union[str, None] = None
-    bedset_id: Union[str, None] = None
+    construct_method: str | None = None
+    bedset_id: str | None = None
 
 
 class BedSetMinimal(BaseModel):
     id: str
-    name: Union[str, None] = None
-    description: Union[str, None] = None
+    name: str | None = None
+    description: str | None = None
 
 
 class BedMetadataAll(BedMetadataBasic):
-    stats: Union[BedStatsModel, None] = None
-    plots: Union[BedPlots, None] = None
-    files: Union[BedFiles, None] = None
-    universe_metadata: Union[UniverseMetadata, None] = None
-    raw_metadata: Union[BedPEPHub, BedPEPHubRestrict, None] = None
-    bedsets: Union[List[BedSetMinimal], None] = None
+    stats: BedStatsModel | None = None
+    plots: BedPlots | None = None
+    files: BedFiles | None = None
+    universe_metadata: UniverseMetadata | None = None
+    raw_metadata: BedPEPHub | BedPEPHubRestrict | None = None
+    bedsets: list[BedSetMinimal] | None = None
 
 
 class BedListResult(BaseModel):
     count: int
     limit: int
     offset: int
-    results: List[BedMetadataBasic]
+    results: list[BedMetadataBasic]
 
 
 class QdrantSearchResult(BaseModel):
     id: str
     payload: dict = None
     score: float = None
-    metadata: Union[BedMetadataBasic, None] = None
+    metadata: BedMetadataBasic | None = None
 
 
 class BedListSearchResult(BaseModel):
     count: int
     limit: int
     offset: int
-    results: List[QdrantSearchResult] = None
+    results: list[QdrantSearchResult] | None = None
 
 
 class TokenizedBedResponse(BaseModel):
     universe_id: str
     bed_id: str
-    tokenized_bed: List[int]
+    tokenized_bed: list[int]
 
 
 class BedEmbeddingResult(BaseModel):
     identifier: str
     payload: dict
-    embedding: List[float]
+    embedding: list[float]
 
 
 class TokenizedPathResponse(BaseModel):
@@ -244,11 +243,11 @@ class TokenizedPathResponse(BaseModel):
 
 class RefGenValidModel(BaseModel):
     provided_genome: str
-    compared_genome: Union[str, None]
-    genome_digest: Union[str, None]
+    compared_genome: str | None
+    genome_digest: str | None
     xs: float = 0.0
-    oobr: Union[float, None] = None
-    sequence_fit: Union[float, None] = None
+    oobr: float | None = None
+    sequence_fit: float | None = None
     assigned_points: int
     tier_ranking: int
 
@@ -257,8 +256,8 @@ class RefGenValidModel(BaseModel):
 
 class RefGenValidReturnModel(BaseModel):
     id: str
-    provided_genome: Union[str, None] = None
-    compared_genome: List[RefGenValidModel]
+    provided_genome: str | None = None
+    compared_genome: list[RefGenValidModel]
 
 
 class VectorMetadata(BaseModel):
@@ -272,7 +271,7 @@ class VectorMetadata(BaseModel):
     treatment: str
     assay: str
     genome_alias: str
-    genome_digest: Union[str, None] = None
+    genome_digest: str | None = None
     species_name: str
     # summary: str
     # global_sample_id: str

--- a/bbconf/models/bedset_models.py
+++ b/bbconf/models/bedset_models.py
@@ -1,5 +1,4 @@
 import datetime
-from typing import List, Union
 
 from pydantic import BaseModel, ConfigDict, model_validator
 
@@ -24,36 +23,36 @@ class BedSetMetadata(BaseModel):
     md5sum: str
     submission_date: datetime.datetime = None
     last_update_date: datetime.datetime = None
-    statistics: Union[BedSetStats, None] = None
-    plots: Union[BedSetPlots, None] = None
+    statistics: BedSetStats | None = None
+    plots: BedSetPlots | None = None
     description: str = None
     summary: str = None
-    bed_ids: List[str] = None
-    author: Union[str, None] = None
-    source: Union[str, None] = None
+    bed_ids: list[str] = None
+    author: str | None = None
+    source: str | None = None
 
 
 class BedSetListResult(BaseModel):
     count: int
     limit: int
     offset: int
-    results: List[BedSetMetadata]
+    results: list[BedSetMetadata]
 
 
 class BedSetBedFiles(BaseModel):
     count: int
-    results: List[BedMetadataBasic]
+    results: list[BedMetadataBasic]
 
 
 class BedSetPEP(BaseModel):
     sample_name: str
     original_name: str
-    genome_alias: Union[str, None] = ""
-    genome_digest: Union[str, None] = ""
-    bed_compliance: Union[str, None] = ""
-    data_format: Union[str, None] = ""
-    description: Union[str, None] = ""
-    url: Union[str, None] = ""
+    genome_alias: str | None = ""
+    genome_digest: str | None = ""
+    bed_compliance: str | None = ""
+    data_format: str | None = ""
+    description: str | None = ""
+    url: str | None = ""
 
     @model_validator(mode="before")
     def remove_underscore_keys(cls, values):

--- a/bbconf/models/drs_models.py
+++ b/bbconf/models/drs_models.py
@@ -1,5 +1,4 @@
 import datetime
-from typing import List, Optional, Union
 
 from pydantic import BaseModel
 
@@ -7,23 +6,23 @@ from pydantic import BaseModel
 # DRS Models
 class AccessURL(BaseModel):
     url: str
-    headers: Optional[dict] = None
+    headers: dict | None = None
 
 
 class AccessMethod(BaseModel):
     type: str
-    access_url: Optional[AccessURL] = None
-    access_id: Optional[str] = None
-    region: Optional[str] = None
+    access_url: AccessURL | None = None
+    access_id: str | None = None
+    region: str | None = None
 
 
 class DRSModel(BaseModel):
     id: str
-    name: Optional[str] = None
+    name: str | None = None
     self_uri: str
-    size: Union[int, None] = None
-    created_time: Optional[datetime.datetime] = None
-    updated_time: Optional[datetime.datetime] = None
+    size: int | None = None
+    created_time: datetime.datetime | None = None
+    updated_time: datetime.datetime | None = None
     checksums: str
-    access_methods: List[AccessMethod]
-    description: Optional[str] = None
+    access_methods: list[AccessMethod]
+    description: str | None = None

--- a/bbconf/modules/bedfiles.py
+++ b/bbconf/modules/bedfiles.py
@@ -689,7 +689,6 @@ class BedAgentBedFile:
             session.add(new_metadata)
 
             if ref_validation:
-
                 new_gen_refs = self._create_ref_validation_models(
                     ref_validation=ref_validation,
                     bed_id=identifier,
@@ -1554,7 +1553,9 @@ class BedAgentBedFile:
             ),
         )
         if result.status == "completed":
-            _LOGGER.info(f"File with id: {identifier} successfully deleted from qdrant.")
+            _LOGGER.info(
+                f"File with id: {identifier} successfully deleted from qdrant."
+            )
         return None
 
     def exists(self, identifier: str) -> bool:
@@ -2035,7 +2036,6 @@ class BedAgentBedFile:
         )
 
         with Session(self._sa_engine) as session:
-
             if purge:
                 _LOGGER.info("Purging indexed files in the database ...")
                 session.query(Bed).update({Bed.indexed: False})
@@ -2295,7 +2295,6 @@ class BedAgentBedFile:
             )
 
         with Session(self._sa_engine) as session:
-
             bed_objects = session.scalars(statement)
             results = [
                 BedMetadataBasic(

--- a/bbconf/modules/bedfiles.py
+++ b/bbconf/modules/bedfiles.py
@@ -1,7 +1,6 @@
 import datetime
 import os
 from logging import getLogger
-from typing import Dict, List, Union
 
 import numpy as np
 from geniml.bbclient import BBClient
@@ -10,8 +9,8 @@ from gtars.models import RegionSet as GRegionSet
 from pephubclient.exceptions import ResponseError
 from pydantic import BaseModel
 from qdrant_client import models
-from qdrant_client.http.models import PointStruct
 from qdrant_client.http.exceptions import UnexpectedResponse
+from qdrant_client.http.models import PointStruct
 from qdrant_client.models import PointIdsList
 from sqlalchemy import and_, cast, delete, func, or_, select
 from sqlalchemy.dialects import postgresql
@@ -23,9 +22,9 @@ from tqdm import tqdm
 from bbconf.config_parser.bedbaseconfig import BedBaseConfig
 from bbconf.const import (
     DEFAULT_LICENSE,
+    DEFAULT_QDRANT_GENOME_DIGESTS,
     PKG_NAME,
     ZARR_TOKENIZED_FOLDER,
-    DEFAULT_QDRANT_GENOME_DIGESTS,
 )
 from bbconf.db_utils import (
     Bed,
@@ -368,7 +367,7 @@ class BedAgentBedFile:
 
         return bed_classification
 
-    def get_objects(self, identifier: str) -> Dict[str, FileModel]:
+    def get_objects(self, identifier: str) -> dict[str, FileModel]:
         """
         Get all object related to bedfile
 
@@ -522,7 +521,7 @@ class BedAgentBedFile:
         plots: dict = None,
         files: dict = None,
         classification: dict = None,
-        ref_validation: Union[Dict[str, BaseModel], None] = None,
+        ref_validation: dict[str, BaseModel] | None = None,
         license_id: str = DEFAULT_LICENSE,
         upload_qdrant: bool = False,
         upload_pephub: bool = False,
@@ -716,12 +715,12 @@ class BedAgentBedFile:
     def update(
         self,
         identifier: str,
-        stats: Union[dict, None] = None,
-        metadata: Union[dict, None] = None,
-        plots: Union[dict, None] = None,
-        files: Union[dict, None] = None,
-        classification: Union[dict, None] = None,
-        ref_validation: Union[Dict[str, BaseModel], None] = None,
+        stats: dict | None = None,
+        metadata: dict | None = None,
+        plots: dict | None = None,
+        files: dict | None = None,
+        classification: dict | None = None,
+        ref_validation: dict[str, BaseModel] | None = None,
         license_id: str = DEFAULT_LICENSE,
         upload_qdrant: bool = False,
         upload_pephub: bool = False,
@@ -1025,7 +1024,7 @@ class BedAgentBedFile:
         self,
         sa_session: Session,
         bed_id: str,
-        ref_validation: Dict[str, BaseModel],
+        ref_validation: dict[str, BaseModel],
         provided_genome: str = "",
     ) -> None:
         """
@@ -1060,7 +1059,7 @@ class BedAgentBedFile:
 
     def _create_ref_validation_models(
         self,
-        ref_validation: Dict[str, BaseModel],
+        ref_validation: dict[str, BaseModel],
         bed_id: str,
         provided_genome: str = None,
     ) -> list[GenomeRefStats]:
@@ -1163,7 +1162,7 @@ class BedAgentBedFile:
     def upload_file_qdrant(
         self,
         bed_id: str,
-        bed_file: Union[str, GRegionSet],
+        bed_file: str | GRegionSet,
         payload: dict = None,
     ) -> None:
         """
@@ -1191,7 +1190,7 @@ class BedAgentBedFile:
         )
         return None
 
-    def _embed_file(self, bed_file: Union[str, GRegionSet]) -> np.ndarray:
+    def _embed_file(self, bed_file: str | GRegionSet) -> np.ndarray:
         """
         Create embedding for bed file
 
@@ -1223,7 +1222,7 @@ class BedAgentBedFile:
         vec_dim = bed_embedding.shape[0]
         return bed_embedding.reshape(1, vec_dim)
 
-    def _get_umap_file(self, bed_file: Union[str, GRegionSet]) -> np.ndarray:
+    def _get_umap_file(self, bed_file: str | GRegionSet) -> np.ndarray:
         """
         Create UMAP for bed file
 
@@ -1452,7 +1451,7 @@ class BedAgentBedFile:
                 .join(BedMetadata, Bed.id == BedMetadata.id)
                 .where(
                     and_(
-                        Bed.file_indexed == False,
+                        Bed.file_indexed.is_(False),
                         # Bed.genome_alias == QDRANT_GENOME,
                         # BedMetadata.global_experiment_id.contains(['encode']) # If we want only encode data
                         Bed.genome_digest.in_(DEFAULT_QDRANT_GENOME_DIGESTS),
@@ -1463,7 +1462,7 @@ class BedAgentBedFile:
 
             annotation_results = session.scalars(statement)
 
-            results: List[Bed] = [result for result in annotation_results]
+            results: list[Bed] = [result for result in annotation_results]
             if not results:
                 _LOGGER.info("No files to reindex in qdrant.")
                 return None
@@ -1554,6 +1553,8 @@ class BedAgentBedFile:
                 points=[identifier],
             ),
         )
+        if result.status == "completed":
+            _LOGGER.info(f"File with id: {identifier} successfully deleted from qdrant.")
         return None
 
     def exists(self, identifier: str) -> bool:
@@ -1817,7 +1818,7 @@ class BedAgentBedFile:
 
     def get_missing_plots(
         self, plot_name: str, limit: int = 1000, offset: int = 0
-    ) -> List[str]:
+    ) -> list[str]:
         """
         Get list of bed files that are missing plot
 
@@ -1855,7 +1856,7 @@ class BedAgentBedFile:
 
         return results
 
-    def get_missing_stats(self, limit: int = 1000, offset: int = 0) -> List[str]:
+    def get_missing_stats(self, limit: int = 1000, offset: int = 0) -> list[str]:
         """
         Get list of bed files that are missing statistics
 
@@ -1879,7 +1880,7 @@ class BedAgentBedFile:
 
         return results
 
-    def get_missing_files(self, limit: int = 1000, offset: int = 0) -> List[str]:
+    def get_missing_files(self, limit: int = 1000, offset: int = 0) -> list[str]:
         """
         Get list of bed files that are missing files (bigBed files)
 
@@ -1911,7 +1912,7 @@ class BedAgentBedFile:
         return results
 
     def get_unprocessed(
-        self, limit: int = 1000, offset: int = 0, genome: Union[str, list, None] = None
+        self, limit: int = 1000, offset: int = 0, genome: str | list | None = None
     ) -> BedListResult:
         """
         Get bed files that are not processed.
@@ -1976,9 +1977,9 @@ class BedAgentBedFile:
 
     def _update_sources(
         self,
-        identifier,
-        global_sample_id: List[str] = None,
-        global_experiment_id: List[str] = None,
+        identifier: str,
+        global_sample_id: list[str] | None = None,
+        global_experiment_id: list[str] | None = None,
     ) -> None:
         """
         Add global sample and experiment ids to the bed file if they are missing
@@ -2030,7 +2031,7 @@ class BedAgentBedFile:
         statement = (
             select(Bed)
             .join(BedMetadata, Bed.id == BedMetadata.id)
-            .where(Bed.indexed == False)
+            .where(Bed.indexed.is_(False))
         )
 
         with Session(self._sa_engine) as session:
@@ -2116,7 +2117,7 @@ class BedAgentBedFile:
                         )
                         pbar.write("Uploaded batch to qdrant.")
                         points = []
-                        print(operation_info.status)
+                        _LOGGER.info(operation_info.status)
                         assert (
                             operation_info.status == "completed"
                             or operation_info.status == "acknowledged"

--- a/bbconf/modules/bedsets.py
+++ b/bbconf/modules/bedsets.py
@@ -184,7 +184,6 @@ class BedAgentBedSet:
                 bedfile_meta_list = []
 
                 for bedfile in bedfiles:
-
                     try:
                         annotation = bedfile.annotations.__dict__
                     except AttributeError:
@@ -616,7 +615,6 @@ class BedAgentBedSet:
         """
 
         with Session(self._db_engine.engine) as session:
-
             statement = (
                 select(BedSets)
                 .where(BedSets.processed.is_(False))

--- a/bbconf/modules/bedsets.py
+++ b/bbconf/modules/bedsets.py
@@ -1,5 +1,4 @@
 import logging
-from typing import Dict, List
 
 from geniml.io.utils import compute_md5sum_bedset
 from sqlalchemy import Float, Numeric, func, or_, select
@@ -121,7 +120,7 @@ class BedAgentBedSet:
                     )
         return bedset_files
 
-    def get_objects(self, identifier: str) -> Dict[str, FileModel]:
+    def get_objects(self, identifier: str) -> dict[str, FileModel]:
         """
         Get objects for bedset by identifier.
 
@@ -281,11 +280,11 @@ class BedAgentBedSet:
         self,
         identifier: str,
         name: str,
-        bedid_list: List[str],
-        description: str = None,
+        bedid_list: list[str],
+        description: str | None = None,
         statistics: bool = False,
-        annotation: dict = None,
-        plots: dict = None,
+        annotation: dict | None = None,
+        plots: dict | None = None,
         upload_pephub: bool = False,
         upload_s3: bool = False,
         local_path: str = "",
@@ -393,7 +392,7 @@ class BedAgentBedSet:
         _LOGGER.info(f"Bedset '{identifier}' was created successfully")
         return None
 
-    def _calculate_statistics(self, bed_ids: List[str]) -> BedSetStats:
+    def _calculate_statistics(self, bed_ids: list[str]) -> BedSetStats:
         """
         Calculate statistics for bedset.
 

--- a/bbconf/modules/objects.py
+++ b/bbconf/modules/objects.py
@@ -1,6 +1,6 @@
 import datetime
 import logging
-from typing import List, Literal, Union
+from typing import Literal
 
 from bbconf.config_parser.bedbaseconfig import BedBaseConfig
 from bbconf.const import PKG_NAME
@@ -79,7 +79,7 @@ class BBObjects:
         self,
         record_type: Literal["bed", "bedset"],
         record_id: str,
-        result_id: Union[str, List[str]],
+        result_id: str | list[str],
     ) -> FileModel:
         """
         Generic getter that can return a result from either bed or bedset
@@ -157,9 +157,9 @@ class BBObjects:
         base_uri: str,
         object_id: str,
         record_metadata: FileModel,
-        created_time: datetime.datetime = None,
-        modified_time: datetime.datetime = None,
-    ):
+        created_time: datetime.datetime | None = None,
+        modified_time: datetime.datetime | None = None,
+    ) -> DRSModel:
         """
         Construct DRS metadata object
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,8 @@ line-length = 88
 [tool.ruff.lint]
 select = ["E", "F", "I"]
 ignore = ["F403", "F405", "E501"]
+exclude = ["manual_testing.py"]
+
 
 [tool.ruff.lint.isort]
 known-first-party = ["bbconf"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,4 @@
 import os
-import subprocess
-from atexit import register
 
 import pytest
 

--- a/tests/test_bedfile.py
+++ b/tests/test_bedfile.py
@@ -213,7 +213,6 @@ class Test_BedFile_Agent:
 
         # TODO: has to be expanded
         with ContextManagerDBTesting(config=bbagent_obj.config, add_data=True):
-
             bed_file = bbagent_obj.bed.get(BED_TEST_ID, full=True)
             # assert bed_file.annotation.model_dump(exclude_defaults=True) == {}
             assert bed_file.annotation.cell_line == ""

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -3,7 +3,6 @@ import datetime
 import pytest
 
 from bbconf.const import DEFAULT_LICENSE
-from bbconf.exceptions import BedBaseConfError
 from bbconf.models.base_models import UsageModel
 
 from .conftest import SERVICE_UNAVAILABLE

--- a/tests/test_universes.py
+++ b/tests/test_universes.py
@@ -8,7 +8,6 @@ from .utils import BED_TEST_ID, ContextManagerDBTesting
 
 @pytest.mark.skipif(SERVICE_UNAVAILABLE, reason="Database is not available")
 class TestUniverses:
-
     def test_add(self, bbagent_obj):
         with ContextManagerDBTesting(config=bbagent_obj.config, add_data=True):
             bbagent_obj.bed.add_universe(


### PR DESCRIPTION
## Changes:
- Updated all type annotations to modern Python 3.10+ syntax (Union → |, List → list, Dict → dict, Optional → | None)
- Fixed bug in UsageModel where type annotations were incorrectly used as default values
- Replaced print statements with proper logging calls (_LOGGER.info/error)
- Applied SQLAlchemy best practices using .is_(False) instead of == False for boolean comparisons
- Added missing return type annotations and parameter type annotations
- Removed unused imports and unnecessary f-string prefixes
- Minor code cleanup (blank lines, import ordering)


## TODO:
- [ ] Version of pepdbagent updated in `__version__.py` file
- [ ] Changelog updated